### PR TITLE
bucket: fix buffer moving when growing

### DIFF
--- a/pkg/bucket/bucket.go
+++ b/pkg/bucket/bucket.go
@@ -54,7 +54,7 @@ func (b *Bucket) Grow() int {
 	// move wrapped slots to new slots
 	for i := b.maxSteps - 1; i >= b.step; i-- {
 		if binary.BigEndian.Uint16(b.slots[i]) != invalidPktSize {
-			growedSlots[i+b.initCapacity], b.slots[i] = b.slots[i], growedSlots[i+b.initCapacity]
+			growedSlots[i+b.initCapacity], growedSlots[i] = growedSlots[i], growedSlots[i+b.initCapacity]
 		}
 	}
 	b.slots = growedSlots


### PR DESCRIPTION
Why:

Livekit server throws errors like this sometimes:
"could not get packet from bucket,
sequence number mismatch, headSN 52552, sn 52248, cacheSN 52548"
where the sequence number difference is always 300 (default size for video).

This points towards a problem with growing the bucket, as Grow() has
been called since the error is not ErrPacketTooOld

What:

Add a test case for growing a bucket that is full, which reproduces the
issue

Fix the byte array swap that is used for moving the packet slots around
to preserve the original packet buffer order after growing the bucket